### PR TITLE
ファイル名に使えない文字がタイトルに含まれる場合の対応

### DIFF
--- a/qiita.Rmd
+++ b/qiita.Rmd
@@ -15,7 +15,7 @@ jsonlite::write_json(x, paste0(user, '.json'))
 ## Extract data from json
 
 ```{r}
-titles <- map_chr(x, 'title')
+titles <- map_chr(x, 'title') %>% map_chr(str_remove_all, pattern = "[/:\"]")
 dirs <- file.path('md', titles)
 walk(dirs, dir.create, showWarnings = FALSE, recursive = TRUE)
 md <- map(x, 'body')


### PR DESCRIPTION
Windows だけの問題かもしれませんが
タイトルに /": が含まれるとうまくいかなかったので削除するように変更しました